### PR TITLE
Require config dir for cli commands

### DIFF
--- a/dxlclient/_cli/_cli_subcommands.py
+++ b/dxlclient/_cli/_cli_subcommands.py
@@ -180,8 +180,7 @@ def _get_config_argparser():
     :rtype: argparse.ArgumentParser
     """
     parser = argparse.ArgumentParser(add_help=False)
-    parser.add_argument("-c", "--config-dir", metavar="PATH",
-                        default="",
+    parser.add_argument("config_dir", metavar="CONFIG_DIR",
                         help="path to the config directory")
     return parser
 

--- a/dxlclient/test/test_broker.py
+++ b/dxlclient/test/test_broker.py
@@ -16,7 +16,7 @@ from dxlclient.exceptions import MalformedBrokerUriException
 
 class BrokerTest(unittest.TestCase):
     def setUp(self):
-        self.socket_mock = patch('socket.socket', autospec=True).start()
+        self.socket_mock = patch('socket.socket').start()
         self.connection_mock = patch('socket.create_connection').start()
         self.connection_mock.return_value = self.socket_mock
         self.broker = Broker(host_name='localhost')

--- a/dxlclient/test/test_wildcard.py
+++ b/dxlclient/test/test_wildcard.py
@@ -10,7 +10,7 @@ import unittest
 import time
 
 from dxlclient.test.base_test import BaseClientTest
-from nose_parameterized import parameterized
+from parameterized import parameterized
 from mock import Mock, patch
 from threading import Condition
 

--- a/examples/advanced/service_invoker_sample.py
+++ b/examples/advanced/service_invoker_sample.py
@@ -102,7 +102,7 @@ try:
 
             # Invalid input
             else:
-                logger.info("fdsaService Invoker - Invalid input: %s", option)
+                logger.info("Service Invoker - Invalid input: %s", option)
 
 except Exception as e:
     logger.exception("Service Invoker - Exception")


### PR DESCRIPTION
This PR makes the config_dir argument for each of the CLI subcommands -- generatecsr, provisionconfig, and updateconfig -- required rather than optional with the current directory as the default.

For example, the generatecsr subcommand could previously be run like this to target the current directory as the config directory...

```
python -m dxlclient generatecsr myclient
```

... or like this to target "config" as the config directory:

```
python -m dxlclient generatecsr myclient -c config
```

With this PR, the following command would target the current directory as the config directory:

```
python -m dxlclient . myclient
```

This command would use "config" as the config directory:

```
python -m dxlclient config myclient
```

This PR also contains a few other minor changes needed to make tests pass against later library versions:

- Removes the use of autospec for a socket mock for use with later versions of mock due to an apparent bug in the mock library for Python 2.  See [this issue](https://github.com/testing-cabal/mock/issues/323) for more details.

- Makes the mock certificate and certificate request objects used by the cli tests more complete due to some apparent changes in later asn1crypto library versions which are more stringent about the asn1 content.



