### PR TITLE
Add provisioning docs for OpenDXL console and client cli

### DIFF
--- a/docs/sdk/cliprovisioning.rst
+++ b/docs/sdk/cliprovisioning.rst
@@ -1,0 +1,177 @@
+Provisioning from the Command Line
+==================================
+
+You can use the ``provisionconfig`` command line tool to provision the
+configuration data needed for a client to connect to the DXL fabric. For this
+tool to be available, you need to complete the steps in the :doc:`installation`
+section if you have not already.
+
+Note that the command line tool is only available in version 4.0 and later
+of the Python DXL client.
+
+The ``provisionconfig`` tool does the following:
+
+1) Creates a private key and Certificate Signing Request (CSR).
+2) Sends the CSR to a management server -- an ePO server or an OpenDXL-based
+   broker -- for signing.
+3) Stores the client certificate and CA certificate bundle received from the
+   management server to disk.
+4) Creates a ``dxlclient.config`` file which references the certificate
+   artifacts and information for brokers currently available on the DXL fabric.
+
+Basic Example
+*************
+
+Here is an example::
+
+    python -m dxlclient provisionconfig config myeposerver client1
+
+For this example:
+
+* ``config`` is the name of the directory in which the ``dxlclient.config`` and
+  certificate-related artifacts should be stored.
+* ``myeposerver`` is the hostname of a management server.
+* ``client1`` is the value for the Common Name (CN) attribute stored in the
+  subject of the client's CSR and certificate.
+
+The tool supplies a username and password to the server for authentication.
+For ePO or the OpenDXL Broker Console, this would be the same username and
+password that you would use to login to the web interface.
+
+With the options in the command above, the tool prompts for the username
+and password on the command line::
+
+    Enter server username:
+    Enter server password:
+
+On success, you should see lines like the following in the tool output::
+
+    INFO: Saving csr file to config/client.csr
+    INFO: Saving private key file to config/client.key
+    INFO: Saving DXL config file to config/dxlclient.config
+    INFO: Saving ca bundle file to config/ca-bundle.crt
+    INFO: Saving client certificate file to config/client.crt
+
+To avoid the username and password prompts, you can supply command line
+options for them instead, like this::
+
+    python -m dxlclient provisionconfig config myeposerver client1 -u myuser -p mypass
+
+.. _subject-attributes-label:
+
+Including Additional Data in the Certificate Signing Request
+************************************************************
+
+Attributes other than the Common Name (CN) may also optionally be provided for
+the CSR subject. For example::
+
+    python -m dxlclient provisionconfig config myeposerver client1 --country US --state-or-province Oregon --locality Hillsboro --organization Engineering --organizational-unit "DXL Team" --email-address dxl@mcafee.com
+
+By default, the CSR does not include any Subject Alternative Names. To include
+one or more entries of type ``DNS Name``, you can use the ``-s`` option. For
+example::
+
+    python -m dxlclient provisionconfig config myeposerver client1 -s client1.myorg.com client1.myorg.net
+
+.. _encrypting-private-key-label:
+
+Encrypting the Client's Private Key
+***********************************
+
+The private key file which the ``provisionconfig`` command generates can
+optionally be encrypted with a passphrase. For example::
+
+    python -m dxlclient provisionconfig config myeposerver client1 --passphrase
+
+If the passphrase is specified with no trailing option (as above), the tool
+prompts for the passphrase to be used::
+
+    Enter private key passphrase:
+
+The passphrase can alternatively be specified as an additional argument
+following the ``--passpharse`` argument, in which case no prompt is displayed.
+For example::
+
+    python -m dxlclient provisionconfig config myeposerver client1 --passphrase itsasecret
+
+Note that if the private key is encrypted, the passphrase used to encrypt it
+will need to be entered as the client tries to use it to connect to the DXL
+fabric later on. Currently, the only way to enter this passphrase is via a
+prompt made at connection time::
+
+    Enter PEM pass phrase:
+
+Additional Options
+******************
+
+The tool assumes that the default webserver port is 8443, the default port
+under which the ePO web interface is hosted. You can configure the tool to use
+a custom port by using the ``-t`` option. For example::
+
+    python -m dxlclient provisionconfig config myeposerver client1 -t 443
+
+The tool stores each of the certificate artifacts -- the private key, CSR,
+certificate, etc. -- with a base name of ``client`` by default. To use an
+alternative base name for the stored files, use the ``-f`` option. For
+example::
+
+    python -m dxlclient provisionconfig config myeposerver client1 -f theclient
+
+For the command line above, lines similar to the following should appear in the
+output::
+
+    INFO: Saving csr file to config/theclient.csr
+    INFO: Saving private key file to config/theclient.key
+    INFO: Saving DXL config file to config/dxlclient.config
+    INFO: Saving ca bundle file to config/ca-bundle.crt
+    INFO: Saving client certificate file to config/theclient.crt
+
+If you have the management server's CA certificate in a local CA truststore
+file -- one or more PEM-formatted certificates concatenated together into a
+single file -- you can configure the tool to validate the management server's
+certificate against that truststore during TLS session negotiation by supplying
+the ``-e`` option. The name of the truststore file should be supplied along
+with the option, like this::
+
+    python -m dxlclient config myeposerver -e config/ca-bundle.crt
+
+Generating the CSR Separately from Signing the Certificate
+**********************************************************
+
+By default, the ``provisionconfig`` command generates a CSR and immediately
+sends it a management server to be signed. Certificate generation and signing
+could alternatively be performed as separate steps -- for example, to enable a
+workflow where the CSR is forwarded to a separate system / process which may
+obtain the signed certificate at a later time.
+
+To generate the CSR and private key without sending the CSR on to the server,
+the ``generatecsr`` command could be used. For example::
+
+    python -m dxlclient generatecsr config client1
+
+For the command line above, lines similar to the following should appear in the
+output::
+
+    INFO: Saving csr file to config/client.csr
+    INFO: Saving private key file to config/client.key
+
+Note that the ``generatecsr`` command has options similar to those available
+in the ``provisionconfig`` command for including additional subject attributes
+and/or subject alternative names in the generated CSR and for encrypting the
+private key. See the :ref:`subject-attributes-label` and
+:ref:`encrypting-private-key-label` sections for more information.
+
+If the ``provisionconfig`` command includes a ``-r`` option, the
+``COMMON_OR_CSRFILE_NAME`` argument is interpreted as being the name of a
+CSR file to load from disk rather than the Common Name to insert into a new
+CSR file. For example::
+
+    python -m dxlclient provisionconfig config myeposerver -r config/client.csr
+
+In this case, the command line output shows that the certificate and
+configuration-related files received from the server are stored but that no
+new private key or CSR file is generated::
+
+    INFO: Saving DXL config file to config/dxlclient.config
+    INFO: Saving ca bundle file to config/ca-bundle.crt
+    INFO: Saving client certificate file to config/client.crt

--- a/docs/sdk/epoexternalcertissuance.rst
+++ b/docs/sdk/epoexternalcertissuance.rst
@@ -1,0 +1,28 @@
+ePO Management with External Certificate Issuance
+=================================================
+
+If your brokers are managed by ePO but you want to manage issuance of client
+certificates from a Certificate Authority outside of ePO, you can follow the
+steps below to provision the client's configuration:
+
+1. Generate a client private key and certificate. The :doc:`certcreation`
+   section describes one approach for doing this, using ``openssl`` commands to
+   generate a self-signed CA, the client's private key, and the client's
+   certificate.
+2. Follow the steps in the :doc:`epocaimport` section to import the CA
+   certificate into ePO.
+3. Follow the steps in the :doc:`epobrokercertsexport` and
+   :doc:`epobrokerlistexport` sections to export some of the configuration
+   data from ePO which is needed to construct the ``dxlclient.config`` file
+   that the client uses when connecting to the DXL fabric.
+
+Steps
+-----
+
+.. toctree::
+	:maxdepth: 1
+
+	certcreation
+	epocaimport
+	epobrokercertsexport
+	epobrokerlistexport

--- a/docs/sdk/index.rst
+++ b/docs/sdk/index.rst
@@ -3,7 +3,7 @@ Data Exchange Layer (DXL) Python SDK Documentation
 ==================================================
 
 Introduction
--------------------
+------------
 
 .. toctree::
 	:maxdepth: 1
@@ -27,18 +27,19 @@ Provisioning
 .. toctree::
 	:maxdepth: 1
 
-	certcreation
-  	epocaimport
-	epobrokercertsexport
-	epobrokerlistexport
+	provisioningoverview
+	cliprovisioning
+	openconsoleprovisioning
+	epoexternalcertissuance
+	updatingconfigfromcli
 
 Python API
 ----------
 
 .. toctree::
-    :titlesonly:
+	:titlesonly:
 
-    dxlclient
+	dxlclient
 
 Samples
 -------
@@ -46,13 +47,17 @@ Samples
 Configuration
 
 .. toctree::
-    sampleconfig
+	:maxdepth: 1
+
+	sampleconfig
 
 Basic
 
 .. toctree::
-    basiceventsexample
-    basicserviceexample
+	:maxdepth: 1
+
+	basiceventsexample
+	basicserviceexample
 
 Advanced
 
@@ -85,7 +90,7 @@ McAfee Active Response (MAR)
 	marsendauth
 
 Authorization
--------------------
+-------------
 
 .. toctree::
 	:maxdepth: 1

--- a/docs/sdk/openconsoleprovisioning.rst
+++ b/docs/sdk/openconsoleprovisioning.rst
@@ -1,0 +1,8 @@
+Provisioning from the OpenDXL Broker Console
+============================================
+
+If you are using OpenDXL-based brokers, you can provision clients either by
+following the steps in the :doc:`cliprovisioning` section or by using the
+OpenDXL Broker Console GUI. See the
+`OpenDXL Broker Generate Client Configuration <https://github.com/opendxl/opendxl-broker/wiki/Generate-Client-Configuration-Page>`_
+page for more information on the GUI-based provisioning approach.

--- a/docs/sdk/provisioningoverview.rst
+++ b/docs/sdk/provisioningoverview.rst
@@ -1,0 +1,44 @@
+Provisioning Overview
+=====================
+
+In order for a client to connect to the DXL fabric, the client must have a
+trusted certificate and a ``dxlclient.config`` file with broker information.
+This section describes the approaches for provisioning the client configuration
+and updating the client configuration to incorporate changes over time.
+
+Creating Certificate Files and Configuration
+********************************************
+
+The following approaches are available for creating certificate and
+configuration content:
+
+1. To generate certificate and configuration files from the command line -- for
+   either an OpenDXL-based or ePO-managed broker -- see the
+   :doc:`cliprovisioning` section. Note that with this approach, the
+   certificate and key used by the Certificate Authority is managed entirely by
+   the server. Note that the provisioning command line tool is only available
+   in version 4.0 and later of the Python DXL client.
+
+2. If you are using OpenDXL-based brokers but do not want to use the command
+   line interface, you can use the OpenDXL Broker Console to generate and
+   download certificate and configuration files. See the
+   :doc:`openconsoleprovisioning` section for more information.
+
+3. If your brokers are managed by ePO but you want to manage issuance of client
+   certificates from a Certificate Authority outside of ePO, see the steps in
+   the :doc:`epoexternalcertissuance` section.
+
+Updating Certificate Files and Configuration
+********************************************
+
+After the initial configuration is established for a new client, the
+configuration may periodically need to be updated. For example, new brokers may
+be connected to the fabric or prior brokers may be removed from the fabric.
+Additionally, the server may periodically issue new certificates which clients
+should import into their truststore. While this information could be updated
+"manually", the :doc:`updatingconfigfromcli` section describes how client
+configuration can be updated programmatically via the use of a command line
+tool.
+
+Note that the update configuration command line tool is only available in
+version 4.0 and later of the Python DXL client.

--- a/docs/sdk/sampleconfig.rst
+++ b/docs/sdk/sampleconfig.rst
@@ -1,16 +1,48 @@
 Samples Configuration
 =====================
 
-Prior to running any of the examples, make sure you have completed the following:
+Prior to running any of the examples, make sure you have completed the
+following:
 
 * Installed the Python SDK (:doc:`installation`)
-* Created the Certificate Authority (CA) and Client Certificate Files (:doc:`certcreation`)
-* Import Certificate Authority (CA) into ePO (:doc:`epocaimport`)
-* Exported the Broker Certificates (:doc:`epobrokercertsexport`)
-* Exported the list of DXL Brokers (:doc:`epobrokerlistexport`)
+* Provisioned a private key, certificates, and configuration for the client (:doc:`provisioningoverview`)
 
-The final step prior to running the samples is to populate the contents of the ``dxlclient.config``
-file that is used by the samples.
+Using Files from Command Line or OpenDXL Broker Console Provisioning
+********************************************************************
+
+If you used either the :doc:`cliprovisioning` or :doc:`openconsoleprovisioning`
+approach for client provisioning, you should just need to copy the following
+files created during the provisioning process to the ``sample`` sub-directory
+of the Python DXL SDK:
+
+1. ``dxlclient.config`` file
+2. File referenced by the ``BrokerCertChain`` setting in the ``[Certs]`` section
+   from the ``dxlclient.config`` file - for example, ``ca-bundle.crt`` or
+   ``ca-broker.crt``.
+3. File referenced by the ``CertFile`` setting in the ``[Certs]`` section
+   from the ``dxlclient.config`` file - for example, ``client.crt``.
+4. File referenced by the ``PrivateKey`` setting in the ``[Certs]`` section
+   from the ``dxlclient.config`` file - for example, ``client.key``.
+
+Note that rather than copying all of these files into the ``sample``
+sub-directory, you could instead copy just the ``dxlclient.config`` file and
+modify the corresponding settings in the file to reflect the appropriate
+locations of the certificate and key files.  For example:
+
+    .. code-block:: ini
+
+        [Certs]
+        BrokerCertChain=c:\\certificates\\ca-bundle.crt
+        CertFile=c:\\certificates\\client.crt
+        PrivateKey=c:\\certificates\\client.key
+        ...
+
+Using Files from ePO / External Certificate Provisioning
+********************************************************
+
+If you used the :doc:`epoexternalcertissuance` approach for client
+provisioning, the final step prior to running the samples is to populate the
+contents of the ``dxlclient.config`` file that is used by the samples.
 
 The following steps walk through the process of populating this file:
 
@@ -18,7 +50,7 @@ The following steps walk through the process of populating this file:
 
    The contents should appear as follows:
 
-   .. code-block:: python
+   .. code-block:: ini
 
        [Certs]
        BrokerCertChain=<path-to-cabundle>
@@ -36,7 +68,7 @@ The following steps walk through the process of populating this file:
 
    After completing this step the contents of the configuration file should look similar to:
 
-   .. code-block:: python
+   .. code-block:: ini
 
        [Certs]
        BrokerCertChain=<path-to-cabundle>
@@ -54,7 +86,7 @@ The following steps walk through the process of populating this file:
 
    After completing this step the contents of the configuration file should look similar to:
 
-   .. code-block:: python
+   .. code-block:: ini
 
        [Certs]
        BrokerCertChain=c:\\certificates\\brokercerts.crt
@@ -72,7 +104,7 @@ The following steps walk through the process of populating this file:
 
    After completing this step the contents of the configuration file should look similar to:
 
-   .. code-block:: python
+   .. code-block:: ini
 
        [Certs]
        BrokerCertChain=c:\\certificates\\brokercerts.crt
@@ -82,5 +114,3 @@ The following steps walk through the process of populating this file:
        [Brokers]
        {5d73b77f-8c4b-4ae0-b437-febd12facfd4}={5d73b77f-8c4b-4ae0-b437-febd12facfd4};8883;mybroker.mcafee.com;192.168.1.12
        {24397e4d-645f-4f2f-974f-f98c55bdddf7}={24397e4d-645f-4f2f-974f-f98c55bdddf7};8883;mybroker2.mcafee.com;192.168.1.13
-
-4. At this point you can run the samples included with the Python SDK

--- a/docs/sdk/updatingconfigfromcli.rst
+++ b/docs/sdk/updatingconfigfromcli.rst
@@ -1,0 +1,71 @@
+Updating Client Configuration from the Command Line
+===================================================
+
+Assuming you have previously created a ``dxlclient.config`` file, you can use
+the ``updateconfig`` command line tool to update local client configuration
+from the latest configuration available on management server. For this tool to
+be available, you need to complete the steps in the :doc:`installation` section
+if you have not already. If you used the :doc:`epoexternalcertissuance`
+provisioning approach but have not yet created the ``dxlclient.config`` file,
+see the :doc:`sampleconfig` section for details on how to create the file.
+
+Note that the update configuration command line tool is only available in
+version 4.0 and later of the Python DXL client.
+
+The ``updateconfig`` tool does the following:
+
+1) Retrieves the latest CA certificate bundle from the server and stores it
+   at the file referenced by the ``BrokerCertChain`` setting in the ``[Certs]``
+   section of the ``dxlclient.config`` file.
+
+2) Retrieves the latest broker information and updates the ``[Brokers]``
+   section of the ``dxlclient.config`` file with that information.
+
+Basic Example
+*************
+
+Here is an example::
+
+    python -m dxlclient updateconfig config myeposerver
+
+For this example, ``config`` is the name of the directory in which the
+``dxlclient.config`` file resides and ``myeposerver`` is the hostname of an
+ePO management server.
+
+The tool supplies a username and password to the server for authentication.
+For ePO or the OpenDXL Broker Console, this would be the same username and
+password that you would use to login to the web interface.
+
+With the options in the command above, the tool prompts for the username
+and password on the command line::
+
+    Enter server username:
+    Enter server password:
+
+On success, you should see lines like the following in the tool output::
+
+    INFO: Updating certs in config/ca-bundle.crt
+    INFO: Updating DXL config file at config/dxlclient.config
+
+To avoid the username and password prompts, you can supply command line
+options for them instead, like this::
+
+    python -m dxlclient updateconfig config myeposerver -u myuser -p mypass
+
+Additional Options
+******************
+
+The tool assumes that the default webserver port is 8443, the default port
+under which the ePO web interface is hosted. You can configure the tool to use
+a custom port by using the ``-t`` option. For example::
+
+    python -m dxlclient updateconfig config myeposerver -t 443
+
+If you have the management server's CA certificate in a local CA truststore
+file -- one or more PEM-formatted certificates concatenated together into a
+single file -- you can configure the tool to validate the management server's
+certificate against that truststore during TLS session negotiation by supplying
+the ``-e`` option. The name of the truststore file should be supplied along
+with the option, like this::
+
+    python -m dxlclient updateconfig config myeposerver -e config/ca-bundle.crt


### PR DESCRIPTION
This PR updates the provisioning-related docs to include information about how to do provisioning with each of the different approaches that will be available in DXL 4.0:

* ePO with external cert issuance (pre-existing)
* Command-line (new for 4.0)
* OpenDXL broker console (new for 4.0)