### PR TITLE
Add travis-ci integration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,28 @@
 sudo: false
+
 language: python
+
+services:
+  - docker
+
 python:
   - "2.7"
+
+before_install:
+  - docker pull opendxl/opendxl-broker
+  - docker run -d -p 127.0.0.1:8883:8883 -p 127.0.0.1:8443:8443 opendxl/opendxl-broker
+  - docker ps -a
+
 # command to install dependencies
 install:
   - pip install .
+
+before_script:
+  - python -m dxlclient provisionconfig dxlclient/test 127.0.0.1 client -u admin -p password
+  - cp dxlclient/test/dxlclient.config dxlclient/test/client_config.cfg
+  - sed -i -e "s/external/unique_broker_id_1/g" -e "/local/d" dxlclient/test/client_config.cfg
+  - cat dxlclient/test/client_config.cfg
+
 # command to run tests
 script:
-  - python setup.py nosetests -a !system,!manual,!event_test,!load
+  - python setup.py nosetests -a !manual -I "subs_count_test.py" -e "(test_dxl_client_connection|execute_con_disc_test|test_dxlclient_subscription|execute_subs__unsubs_test|test_register_service_weak_reference_after_connect|test_wildcard_performance)"

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,10 @@
+sudo: false
+language: python
+python:
+  - "2.7"
+# command to install dependencies
+install:
+  - pip install .
+# command to run tests
+script:
+  - python setup.py nosetests -a !system,!manual,!event_test,!load

--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
 # OpenDXL Python Client
 [![License](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](https://opensource.org/licenses/Apache-2.0)
+[![Build Status](https://travis-ci.org/opendxl-client-python/opendxl-client-python.png?branch=master)](https://travis-ci.org/opendxl-client-python/opendxl-client-python)
 
 ## Overview
 

--- a/dxlclient/test/test_dxlclient.py
+++ b/dxlclient/test/test_dxlclient.py
@@ -573,7 +573,8 @@ class DxlClientSystemClientTest(BaseClientTest):
     def test_client_raises_exception_when_cannot_sync_connect_to_broker(self):
 
         with self.create_client() as client:
-            broker = Broker("localhost", UuidGenerator.generate_id_as_string(), "127.0.0.1")
+            broker = Broker("localhost", UuidGenerator.generate_id_as_string(),
+                            "127.0.0.255", 58883)
             client._config.brokers = [broker]
 
             with self.assertRaises(DxlException):


### PR DESCRIPTION
This commit adds a Travis configuration which allows for non-system level
tests, e.g., tests that don't require external infrastructure like brokers, to
be run for github PRs and commits.