### PR TITLE
Release service and callback handler locks before invoking callbacks

### DIFF
--- a/dxlclient/_callback_manager.py
+++ b/dxlclient/_callback_manager.py
@@ -51,18 +51,24 @@ class _CallbackManager(_BaseObject):
             if not issubclass(callback.__class__, MessageCallback):
                 raise ValueError("Type mismatch on callback argument")
 
-    def _replace_callbacks_by_channel_with_copy(self):
+    def _get_callbacks_by_channel_copy(self):
         """
-        Replace the current value for self.callbacks_by_channel with a copy.
-        This is used when methods are about to make changes to the content
-        of self.callbacks_by_channel. The use of this method allows other
-        methods to access the content within the self.callbacks_by_channel
-        object without needing to hold the service lock the entire time.
+        Get a copy of the contents of self.callbacks_by_channel. This is used
+        when methods are about to make changes to the content of
+        self.callbacks_by_channel. The use of this method allows other methods
+        to access the content within the self.callbacks_by_channel object
+        without needing to hold a lock.
+
+        :return: Copy of the self.callbacks_by_channel dictionary. The memory
+            for the keys is copied. The memory for the arrays in the values for
+            each key is copied as well. The individual members of each array,
+            however, will be the same references as in the arrays in the
+            current self.callbacks_by_channel dictionary.
         """
-        self.callbacks_by_channel = self.callbacks_by_channel.copy()
-        for channel in self.callbacks_by_channel:
-            self.callbacks_by_channel[channel] = list(
-                self.callbacks_by_channel[channel])
+        callbacks_by_channel = self.callbacks_by_channel.copy()
+        for channel in callbacks_by_channel:
+            callbacks_by_channel[channel] = list(callbacks_by_channel[channel])
+        return callbacks_by_channel
 
     def add_callback(self, channel="", callback=None):
         """
@@ -82,17 +88,18 @@ class _CallbackManager(_BaseObject):
         with self.lock:
             if _has_wildcard(channel):
                 self.wildcarding_enabled = True
-            # Replace the contents of self.callbacks_by_channel with a copy
-            # before adding the new callback into it. This avoids causing
-            # issues with any readers using the current value of the object.
-            self._replace_callbacks_by_channel_with_copy()
-            callbacks = self.callbacks_by_channel.get(channel)
+            # Add the new callback into a copy of the contents of
+            # self.callbacks_by_channel. This avoids causing issues with any
+            # readers using the current value of the object.
+            callbacks_by_channel = self._get_callbacks_by_channel_copy()
+            callbacks = callbacks_by_channel.get(channel)
             if callbacks is None:
                 callbacks = []
             if not callback in callbacks:
                 callbacks.append(callback)
-                self.callbacks_by_channel[channel] = callbacks
+                callbacks_by_channel[channel] = callbacks
                 rc = True  # pylint: disable=invalid-name
+            self.callbacks_by_channel = callbacks_by_channel
         return rc
 
     def remove_callback(self, channel="", callback=None):
@@ -110,26 +117,26 @@ class _CallbackManager(_BaseObject):
 
         rc = False  # pylint: disable=invalid-name
         with self.lock:
-            # Replace the contents of self.callbacks_by_channel with a copy
-            # before removing the callback from it. This avoids causing issues
-            # with any readers using the current value of the object.
-            self._replace_callbacks_by_channel_with_copy()
-            callbacks = self.callbacks_by_channel.get(channel)
+            # Remove the callback from a copy of the contents of
+            # self.callbacks_by_channel. This avoids causing issues with any
+            # readers using the current value of the object.
+            callbacks_by_channel = self._get_callbacks_by_channel_copy()
+            callbacks = callbacks_by_channel.get(channel)
             if callbacks is not None:
                 callbacks.remove(callback)
                 if len(callbacks) == 0:
-                    del self.callbacks_by_channel[channel]
+                    del callbacks_by_channel[channel]
                 else:
-                    self.callbacks_by_channel[channel] = callbacks
+                    callbacks_by_channel[channel] = callbacks
                 rc = True  # pylint: disable=invalid-name
-
             #Determine if any wildcard exist
             if self.wildcarding_enabled:
                 self.wildcarding_enabled = False
-                for current_channel_name in self.callbacks_by_channel.keys():
+                for current_channel_name in callbacks_by_channel.keys():
                     if _has_wildcard(current_channel_name):
                         self.wildcarding_enabled = True
                         break
+            self.callbacks_by_channel = callbacks_by_channel
         return rc
 
     def fire_message(self, message):
@@ -140,16 +147,11 @@ class _CallbackManager(_BaseObject):
         :param message: The message to fire
         :return: None
         """
-        with self.lock:
-            # While in the lock, store the current value of
-            # self.callbacks_by_channel in a local variable before accessing its
-            # contents. This should ensure that if self.callbacks_by_channel is
-            # reassigned after the lock is released that no concurrent
-            # modification errors are encountered. This method should avoid
-            # holding the lock during processing of the _fire_message calls
-            # later since downstream calls could be made back into this class,
-            # potentially leading to deadlocks.
-            callbacks_by_channel = self.callbacks_by_channel
+        # Store the current value of self.callbacks_by_channel in a local
+        # variable before accessing its contents. This should ensure that if
+        # self.callbacks_by_channel is reassigned while iterating over its
+        # contents that no concurrent modification errors are encountered.
+        callbacks_by_channel = self.callbacks_by_channel
 
         # Fire for global listeners (channel="")
         self._fire_message(callbacks_by_channel.get(""), message)

--- a/dxlclient/service.py
+++ b/dxlclient/service.py
@@ -587,6 +587,10 @@ class _ServiceManager(RequestCallback):
 
             # Add service to registry
             service_handler = _ServiceRegistrationHandler(self.__client, service_reg_info)
+            # Replace the contents of self.services with a copy before adding
+            # the new service handler into it. This avoids causing issues with
+            # any readers using the current value of the object.
+            self.services = self.services.copy()
             self.services[service_reg_info._service_id] = service_handler
 
             # Subscribe channels
@@ -631,6 +635,10 @@ class _ServiceManager(RequestCallback):
                     logger.error("Error sending unregister service event for " +
                          service_handler.service_type + " (" + service_handler.instance_id + "): " + str(ex))
 
+            # Replace the contents of self.services with a copy before removing
+            # the service handler from it. This avoids causing issues with any
+            # readers using the current value of the object.
+            self.services = self.services.copy()
             del self.services[service_id]
             service_handler.destroy(unregister=False)
 
@@ -642,17 +650,26 @@ class _ServiceManager(RequestCallback):
         :return: None.
         """
         with self.lock:
-            service_instance_id = request.service_id
-            if not service_instance_id:
-                for service in self.services:
-                    self._on_request(self.services[service], request)
+            # While in the lock, store the current value of self.services
+            # in a local variable before accessing its contents. This should
+            # ensure that if self.callbacks_by_channel is reassigned after the
+            # lock is released that no concurrent modification errors are
+            # encountered. This method should avoid holding the lock during
+            # processing of the _on_request calls later since downstream calls
+            # could be made back into this class, potentially leading to
+            # deadlocks.
+            services = self.services
+        service_instance_id = request.service_id
+        if not service_instance_id:
+            for service_id in services:
+                self._on_request(services[service_id], request)
+        else:
+            service_registration_handler = services.get(service_instance_id)
+            if service_registration_handler:
+                self._on_request(service_registration_handler, request)
             else:
-                service_registration_handler = self.services.get(service_instance_id)
-                if service_registration_handler:
-                    self._on_request(service_registration_handler, request)
-                else:
-                    logger.warning("No service with GUID " + service_instance_id + " registered. Ignoring request.")
-                    self.send_service_not_found_error_message(request)
+                logger.warning("No service with GUID " + service_instance_id + " registered. Ignoring request.")
+                self.send_service_not_found_error_message(request)
 
     def send_service_not_found_error_message(self, request):
         """
@@ -681,22 +698,25 @@ class _ServiceManager(RequestCallback):
         :return: None
         """
         with self.lock:
+            new_services = {}
             for service_id in self.services:
-                if self.services[service_id].is_deleted() or self.services[service_id].is_invalid_reference():
+                service_handler = self.services[service_id]
+                if service_handler.is_deleted() or service_handler.is_invalid_reference():
                     try:
-                        self.services[service_id].send_unregister_service_event()
-                        del self.services[service_id]
+                        service_handler.send_unregister_service_event()
                     except Exception, ex:
                         logger.error("Error sending unregister service event for " +
-                                     self.services[service_id].service_type + " (" +
-                                     self.services[service_id].instance_id + "): " + str(ex))
+                                     service_handler.service_type + " (" +
+                                     service_handler.instance_id + "): " + str(ex))
                 else:
+                    new_services[service_id] = service_handler
                     try:
-                        self.services[service_id].start_timer()
+                        service_handler.start_timer()
                     except Exception, ex:
                         logger.error("Failed to start timer thread for service " +
-                                     self.services[service_id].service_type + " (" +
-                                     self.services[service_id].instance_id + "): " + str(ex))
+                                     service_handler.service_type + " (" +
+                                     service_handler.instance_id + "): " + str(ex))
+            self.services = new_services
 
     def on_disconnect(self):
         """
@@ -706,13 +726,13 @@ class _ServiceManager(RequestCallback):
         :return: None.
         """
         with self.lock:
-
-            for handler in self.services:
+            for service_id in self.services:
+                service_handler = self.services[service_id]
                 if self.__client.connected:
                     try:
-                        self.services[handler].send_unregister_service_event()
+                        service_handler.send_unregister_service_event()
                     except Exception, ex:
                         logger.error("Error sending unregister service event for " +
-                                     self.services[handler].service_type + " (" +
-                                     self.services[handler].instance_id + "): " + str(ex))
-                self.services[handler].stop_timer()
+                                     service_handler.service_type + " (" +
+                                     service_handler.instance_id + "): " + str(ex))
+                service_handler.stop_timer()

--- a/dxlclient/service.py
+++ b/dxlclient/service.py
@@ -564,7 +564,7 @@ class _ServiceManager(RequestCallback):
     def destroy(self):
         """Destroys the service manager (releases resources)"""
         with self.lock:
-            for key in self.services.keys():
+            for key in list(self.services.keys()):
                 self.remove_service(key)
             self.__client = None
 

--- a/dxlclient/service.py
+++ b/dxlclient/service.py
@@ -592,7 +592,6 @@ class _ServiceManager(RequestCallback):
             # the object.
             services = self.services.copy()
             services[service_reg_info._service_id] = service_handler
-            self.services = services
 
             # Subscribe channels
             for channel in service_reg_info.topics:
@@ -601,6 +600,8 @@ class _ServiceManager(RequestCallback):
 
             if self.__client.connected:
                 service_handler.start_timer()
+
+            self.services = services
 
     def remove_service(self, service_id):
         """
@@ -641,8 +642,8 @@ class _ServiceManager(RequestCallback):
             # the object.
             services = self.services.copy()
             del services[service_id]
-            self.services = services
             service_handler.destroy(unregister=False)
+            self.services = services
 
     def on_request(self, request):
         """


### PR DESCRIPTION
Previously, the _ServiceManager.on_request() and
_CallbackManager.fire_message() calls would lock access to the service
and callback objects while callbacks were being delivered. If any
calls from those callbacks were made to add/remove a service or
callback, a thread deadlock could occur.

In this commit, the locks on the service and callback variables from
within the on_request() and fire_message() methods are only held long
enough to get a reference to a copy of the related data which will not
change during delivery of a callback. The locks are released before the
callbacks are invoked, preventing the deadlock.