### PR TITLE
Make subscribe and unsubscribe synchronous

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -25,4 +25,4 @@ before_script:
 
 # command to run tests
 script:
-  - python setup.py nosetests -a !manual -I "subs_count_test.py" -e "(test_dxl_client_connection|execute_con_disc_test|test_dxlclient_subscription|execute_subs__unsubs_test|test_register_service_weak_reference_after_connect|test_wildcard_performance)"
+  - python setup.py nosetests --verbosity 2 -a !manual -I "subs_count_test.py" -e "(test_dxl_client_connection|execute_con_disc_test|test_register_service_weak_reference_after_connect|test_wildcard_performance)"

--- a/dxlclient/test/dxlclient_test.py
+++ b/dxlclient/test/dxlclient_test.py
@@ -29,20 +29,14 @@ class DxlClientTest (BaseClientTest):
     # Tests the subscribe and unsubscribe methods of the DxlClient
     #
     @attr('system')
-    def test_dxlclient_subscription(self):
-        self.execute_subs__unsubs_test()
-
-    def execute_subs__unsubs_test(self):
+    def test_subscribe_and_unsubscribe(self):
         with self.create_client(max_retries=0) as client:
-            try:
-                client.connect()
-                topic = UuidGenerator.generate_id_as_string()
-                client.subscribe(topic)
-                time.sleep(0.5)
-                client.unsubscribe(topic)
-                client.disconnect()
-            except Exception, e:
-                print e.message
+            client.connect()
+            topic = UuidGenerator.generate_id_as_string()
+            client.subscribe(topic)
+            self.assertIn(topic, client.subscriptions)
+            client.unsubscribe(topic)
+            self.assertNotIn(topic, client.subscriptions)
 
     #
     # Test to ensure that ErrorResponse messages can be successfully delivered


### PR DESCRIPTION
Previously, the client subscribe and unsubscribe calls were
asynchronous. In this commit, these calls wait for a corresponding ack
to be delivered from the broker before returning control to the caller.
A maximum timeout of 120 seconds is used to wait for an ack. If the
timeout is exceeded, a WaitTimeoutException is raised.