### PR TITLE
Add disconnect wait loop and move reset_current_broker call up

### DIFF
--- a/dxlclient/test/dxlclient_test.py
+++ b/dxlclient/test/dxlclient_test.py
@@ -14,16 +14,12 @@ class DxlClientTest (BaseClientTest):
     # Tests the connect and disconnect methods of the DxlClient
     #
     @attr('system')
-    def test_dxl_client_connection(self):
-        self.execute_con_disc_test()
-
-    def execute_con_disc_test(self):
+    def test_connect_and_disconnect(self):
         with self.create_client(max_retries=0) as client:
-            try:
-                client.connect()
-                client.disconnect()
-            except Exception, e:
-                print e.message
+            client.connect()
+            self.assertTrue(client.connected)
+            client.disconnect()
+            self.assertFalse(client.connected)
 
     #
     # Tests the subscribe and unsubscribe methods of the DxlClient

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [nosetests]
 verbosity=2
 attr=!manual
-exclude=(test_dxl_client_connection|execute_con_disc_test|test_register_service_weak_reference_after_connect|test_wildcard_performance)
+exclude=(test_register_service_weak_reference_after_connect|test_wildcard_performance)
 ignore-files=subs_count_test.py
 exe=1


### PR DESCRIPTION
Previously, two disconnect calls made back to back could lead to the
second call trying to perform connection cleanup which was already
partially in process from the first call. Depending upon timing, this
could lead to the second call blocking / hanging indefinitely. In this
commit, a wait loop similar to the one used in the connect() method for
the connection state to change was added to the disconnect() method.
This should significantly reduce the likelihood of redundant/conflicting
disconnect() operations overlapping one another.

Previously, the reset_current_broker() call made to clear out the
current broker was made during processing of the _on_disconnect_run()
call after notification was delivered to condition waiters that a
disconnect had occurred. If immediately acted upon, this could lead to
the consumer seeing a stale value for the current broker. This commit
moves the reset call before the notification is made in order to reduce
latency for the current broker value change.