### PR TITLE
Set minimum dependency versions for paho-mqtt and msgpack

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -93,9 +93,9 @@ setup(
     install_requires=[
         "asn1crypto",
         "configobj",
-        "msgpack",
+        "msgpack>=0.5",
         "oscrypto",
-        "paho-mqtt",
+        "paho-mqtt>=1.3",
         "requests"
     ],
 


### PR DESCRIPTION
For compatiblity with the Python 3-related changes to the DXL client,
the minimum versions of the msgpack and paho-mqtt dependencies are now
set to 0.5 and 1.3, respectively. The newer paho-mqtt version supports
an additional argument in the on_connect callback which the DXL client
now implements. The newer msgpack and paho-mqtt versions also contain
string/byte handling changes which newer DXL client code depends upon.