### PR TITLE
Output help text when no options passed to CLI

### DIFF
--- a/dxlclient/_cli/__init__.py
+++ b/dxlclient/_cli/__init__.py
@@ -92,13 +92,17 @@ def cli_run():
     """
     parser = _create_argparser()
     _add_subcommand_argparsers(parser)
-    args = parser.parse_args(sys.argv[1:])
 
-    verbosity_level = 0 if args.silent else args.verbose+1
+    input_args = sys.argv[1:]
+    if not input_args:
+        input_args = ["-h"]
+    parsed_args = parser.parse_args(input_args)
+
+    verbosity_level = 0 if parsed_args.silent else parsed_args.verbose+1
     logging.basicConfig(level=_get_log_level(verbosity_level),
                         format=_get_log_formatter(verbosity_level))
     try:
-        args.func(args)
+        parsed_args.func(parsed_args)
     except Exception as ex:  # pylint: disable=broad-except
         logger.error("Command failed. Message: %s", ex)
         if verbosity_level >= 2:

--- a/dxlclient/test/test_cli.py
+++ b/dxlclient/test/test_cli.py
@@ -160,6 +160,7 @@ class CliTest(unittest.TestCase):
         patch.stopall()
 
     @parameterized.expand([
+        ([],),
         ("-h",),
         ("--help",)
     ])


### PR DESCRIPTION
Previously, if no arguments were passed to a CLI command, a 'Namespace'
does not have a 'func' error appeared when running under Python 3
whereas abbreviated help text appeared when running under Python 2. With
the changes in this commit, full help text is printed under both Python
2 and 3.