### PR TITLE
Output more friendly error under Python 3 when CLI subcommand missing

### DIFF
--- a/dxlclient/_cli/__init__.py
+++ b/dxlclient/_cli/__init__.py
@@ -48,6 +48,11 @@ def _add_subcommand_argparsers(parser):
     """
     subparsers = parser.add_subparsers(title="subcommands")
 
+    # Adding these lines to force argparser to validate the presence of a
+    # subcommand in Python 3. See https://bugs.python.org/issue9253#msg186387.
+    subparsers.required = True
+    subparsers.dest = 'subcommand'
+
     for subcommand_class in _SUBCOMMAND_CLASSES:
         subcommand = subcommand_class()
         subcommand_parser = subparsers.add_parser(subcommand.name,


### PR DESCRIPTION
Previously, if one of the optional arguments was supplied for the CLI
(-s or -v) but the subcommand name itself was not, a 'Namespace' does
not have a 'func' error was printed when running under Python 3. This
appears to be due to a change made in the argparser library - see
https://bugs.python.org/issue9253#msg186387. With the changes in this
commit, the presence of the subcommand is validated under both Python 2
and Python 3 even if other optional arguments are supplied.