### PR TITLE
Fixes for pylint issues

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -135,7 +135,8 @@ disable=print-statement,
         too-many-lines,
         fixme,
         protected-access,
-        similarities
+        similarities,
+        useless-object-inheritance
 
 # Enable the message, report, category or checker with the given id(s). You can
 # either give multiple identifier separated by comma (,) or put this option

--- a/dxlclient/__init__.py
+++ b/dxlclient/__init__.py
@@ -56,8 +56,9 @@ class _ObjectTracker(object):
         if self._enabled:
             with self._lock:
                 self._obj_count += 1
-                self._logger.debug("Constructed: " + obj.__module__ + "." + obj.__class__.__name__ \
-                                   + " objCount=" + str(self._obj_count))
+                self._logger.debug(
+                    "Constructed: %s.%s objCount=%d",
+                    obj.__module__, obj.__class__.__name__, self._obj_count)
 
     def obj_destructed(self, obj):
         """
@@ -68,8 +69,9 @@ class _ObjectTracker(object):
         if self._enabled:
             with self._lock:
                 self._obj_count -= 1
-                self._logger.debug("Destructed: " + obj.__module__ + "." + obj.__class__.__name__ \
-                                   + " objCount=" + str(self._obj_count))
+                self._logger.debug(
+                    "Destructed: %s.%s objCount=%d",
+                    obj.__module__, obj.__class__.__name__, self._obj_count)
 
     @property
     def obj_count(self):

--- a/dxlclient/_dxl_utils.py
+++ b/dxlclient/_dxl_utils.py
@@ -42,10 +42,9 @@ class DxlUtils(object):
         splitted = topic.split("/")
         if topic[-1] != "#":
             return "/".join(splitted[:-1]) + "/#"
-        else:
-            if len(topic) == 2:
-                return "#"
-            return "/".join(splitted[:-2]) + "/#"
+        if len(topic) == 2:
+            return "#"
+        return "/".join(splitted[:-2]) + "/#"
 
     @staticmethod
     def _get_wildcards(topic):

--- a/dxlclient/_thread_pool.py
+++ b/dxlclient/_thread_pool.py
@@ -51,8 +51,7 @@ class ThreadPoolWorker(Thread):
                 if func is None:
                     # Exit the thread
                     return
-                else:
-                    func(*args, **kargs)
+                func(*args, **kargs)
             except Exception:  # pylint: disable=broad-except
                 logger.exception("Error in worker thread")
             del func

--- a/dxlclient/service.py
+++ b/dxlclient/service.py
@@ -660,8 +660,11 @@ class _ServiceManager(RequestCallback):
                 try:
                     service_handler.send_unregister_service_event()
                 except Exception as ex: # pylint: disable=broad-except
-                    logger.error("Error sending unregister service event for " +
-                                 service_handler.service_type + " (" + service_handler.instance_id + "): " + str(ex))
+                    logger.error(
+                        "Error sending unregister service event for %s (%s): %s",
+                        service_handler.service_type,
+                        service_handler.instance_id,
+                        ex)
 
             # Remove the service handler from a copy of self.services. This
             # avoids causing issues with any readers using the current value of
@@ -733,17 +736,21 @@ class _ServiceManager(RequestCallback):
                     try:
                         service_handler.send_unregister_service_event()
                     except Exception as ex: # pylint: disable=broad-except
-                        logger.error("Error sending unregister service event for " +
-                                     service_handler.service_type + " (" +
-                                     service_handler.instance_id + "): " + str(ex))
+                        logger.error(
+                            "Error sending unregister service event for %s (%s): %s",
+                            service_handler.service_type,
+                            service_handler.instance_id,
+                            ex)
                 else:
                     services[service_id] = service_handler
                     try:
                         service_handler.start_timer()
                     except Exception as ex: # pylint: disable=broad-except
-                        logger.error("Failed to start timer thread for service " +
-                                     service_handler.service_type + " (" +
-                                     service_handler.instance_id + "): " + str(ex))
+                        logger.error(
+                            "Failed to start timer thread for service %s (%s): %s",
+                            service_handler.service_type,
+                            service_handler.instance_id,
+                            ex)
             self.services = services
 
     def on_disconnect(self):
@@ -760,7 +767,9 @@ class _ServiceManager(RequestCallback):
                     try:
                         service_handler.send_unregister_service_event()
                     except Exception as ex: # pylint: disable=broad-except
-                        logger.error("Error sending unregister service event for " +
-                                     service_handler.service_type + " (" +
-                                     service_handler.instance_id + "): " + str(ex))
+                        logger.error(
+                            "Error sending unregister service event for %s (%s): %s",
+                            service_handler.service_type,
+                            service_handler.instance_id,
+                            ex)
                 service_handler.stop_timer()

--- a/dxlclient/test/event_throughput_runner_test.py
+++ b/dxlclient/test/event_throughput_runner_test.py
@@ -91,7 +91,7 @@ class EventThroughputRunner(BaseClientTest):
         self.execute_t(self.create_client)
         # print self.get_statistics()
 
-    def execute_t(self, client_factory):
+    def execute_t(self, client_factory):  # pylint: disable=too-many-statements
         start = time.time()
         with client_factory() as send_client:
             send_client.connect()

--- a/dxlclient/test/sync_request_troughput_test.py
+++ b/dxlclient/test/sync_request_troughput_test.py
@@ -129,7 +129,7 @@ class SyncRequestTroughputRunner(BaseClientTest):
         output += "Median response time: " + str(median_response_time)
         return output
 
-    def execute_t(self, client_factory):
+    def execute_t(self, client_factory):  # pylint: disable=too-many-statements
 
         with client_factory() as server_client:
             test_service = TestService(server_client, 1)

--- a/dxlclient/test/test_callback_manager.py
+++ b/dxlclient/test/test_callback_manager.py
@@ -12,7 +12,7 @@ Test cases for the CallbackManager class
 from __future__ import absolute_import
 import unittest
 
-import dxlclient.callbacks as callbacks
+from dxlclient import callbacks
 import dxlclient._callback_manager as callback_manager
 
 # pylint: disable=missing-docstring

--- a/dxlclient/test/test_cli.py
+++ b/dxlclient/test/test_cli.py
@@ -246,11 +246,12 @@ class CliTest(unittest.TestCase):
 
     def test_generatecsr_with_subject_alt_names(self):
         with _TempDir("gencsr_sans") as temp_dir, \
-                patch("sys.argv", command_args([
-                    "generatecsr",
-                    temp_dir,
-                    "myclient",
-                    "-s", "host1.com", "host2.com"])):
+                patch("sys.argv",
+                      command_args([
+                          "generatecsr",
+                          temp_dir,
+                          "myclient",
+                          "-s", "host1.com", "host2.com"])):
             cli_run()
 
             csr_file = os.path.join(temp_dir, "client.csr")

--- a/dxlclient/test/test_dxlclient.py
+++ b/dxlclient/test/test_dxlclient.py
@@ -121,11 +121,9 @@ class DxlClientConfigTest(unittest.TestCase):
         def connect_to_broker_slow():
             semaphore.acquire()
             time.sleep(0.1)
-            return
 
         def connect_to_broker_fast():
             semaphore.release()
-            return
 
         slow_broker._connect_to_broker = connect_to_broker_slow
         fast_broker._connect_to_broker = connect_to_broker_fast
@@ -328,7 +326,7 @@ class DxlClientTest(unittest.TestCase):
 
     def test_client_raises_exception_on_connect_when_already_connecting(self):
         self.client._client.connect.side_effect = Exception("An exception!")
-        self.client._thread = threading.Thread()
+        self.client._thread = threading.Thread(target=None)
         self.assertEqual(self.client.connected, False)
         with self.assertRaises(DxlException):
             self.client.connect()

--- a/dxlclient/test/test_request_manager.py
+++ b/dxlclient/test/test_request_manager.py
@@ -12,7 +12,7 @@ Test cases for the RequestManager class
 from __future__ import absolute_import
 import unittest
 
-import dxlclient.exceptions as exceptions
+from dxlclient import exceptions
 from dxlclient.callbacks import ResponseCallback
 from dxlclient import RequestManager
 from dxlclient import Request

--- a/dxlclient/test/test_wildcard.py
+++ b/dxlclient/test/test_wildcard.py
@@ -35,10 +35,9 @@ def topic_splitter(topic):
     splitted = topic.split("/")
     if topic[-1] != "#":
         return "/".join(splitted[:-1]) + "/#"
-    else:
-        if len(topic) == 2:
-            return "#"
-        return "/".join(splitted[:-2]) + "/#"
+    if len(topic) == 2:
+        return "#"
+    return "/".join(splitted[:-2]) + "/#"
 
 class WilcardPerformanceTest(BaseClientTest):
 

--- a/examples/tie/file_rep_sample.py
+++ b/examples/tie/file_rep_sample.py
@@ -68,8 +68,7 @@ def get_tie_file_reputation(client, md5_hex, sha1_hex):
     # Return a dictionary corresponding to the response payload
     if res.message_type != Message.MESSAGE_TYPE_ERROR:
         return json.loads(res.payload.decode(encoding="UTF-8"))
-    else:
-        raise Exception("Error: " + res.error_message + " (" + str(res.error_code) + ")")
+    raise Exception("Error: " + res.error_message + " (" + str(res.error_code) + ")")
 
 # Create the client
 with DxlClient(config) as client:


### PR DESCRIPTION
This commit includes fixes for various issues flagged by a run with the
most recently released pylint versions - 1.9.3 (for Python 2.7) and
2.1.1 (for Python 3.x).

The recently added `useless-object-inheritance` checker is disabled in
order to allow new-style classes deriving from the base `object` type
to be used for Python 2 compatibility without flagging violations
for pylint versions running under Python 3.x.