### PR TITLE
Making useWebSockets config key setting consistent with other config key settings

### DIFF
--- a/dxlclient/_cli/_cli_subcommands.py
+++ b/dxlclient/_cli/_cli_subcommands.py
@@ -649,9 +649,9 @@ class ProvisionDxlClientSubcommand(Subcommand):  # pylint: disable=no-init
 
         dxlconfig.write(config_file)
 
-        # comment out the useWebSockets setting
+        # comment out the UseWebSockets setting
         with open(config_file) as conf_file:
-            config_contents = conf_file.read().replace('useWebSockets', '#useWebSockets')
+            config_contents = conf_file.read().replace('UseWebSockets', '#UseWebSockets')
 
         with open(config_file, "w") as conf_file:
             conf_file.write(config_contents)

--- a/dxlclient/client.py
+++ b/dxlclient/client.py
@@ -24,7 +24,7 @@ from dxlclient._request_manager import RequestManager
 from dxlclient.exceptions import DxlException
 from dxlclient.message import Message, Event, Request, Response, ErrorResponse
 from dxlclient._thread_pool import ThreadPool
-from dxlclient.exceptions import WaitTimeoutException
+from dxlclient.exceptions import WaitTimeoutException, NoBrokerSpecifiedError
 from dxlclient.service import _ServiceManager
 from dxlclient._uuid_generator import UuidGenerator
 from ._dxl_utils import DxlUtils
@@ -703,12 +703,12 @@ class DxlClient(_BaseObject):
             return DXL_ERR_INVALID
 
         logger.info("Waiting for broker list...")
+        if not self._config.brokers:
+            raise NoBrokerSpecifiedError('No broker specified. Please specify at least one broker.')
         self._config_lock.acquire()
         try:
             while not self._thread_terminate and not self._config.brokers:
                 self._config_lock_condition.wait(self._wait_for_policy_delay)
-                if not self._config.brokers:
-                    logger.debug("No broker defined. Waiting for broker list...")
         finally:
             self._config_lock.release()
 

--- a/dxlclient/client_config.py
+++ b/dxlclient/client_config.py
@@ -139,7 +139,7 @@ class DxlClientConfig(_BaseObject):
 
     _GENERAL_SECTION = u"General"
     _CLIENT_ID_SETTING = u"ClientId"
-    _USE_WEBSOCKETS_SETTING = u"useWebSockets"
+    _USE_WEBSOCKETS_SETTING = u"UseWebSockets"
 
     # HTTP Proxy Section
     _PROXY_SECTION = u"Proxy"

--- a/dxlclient/exceptions.py
+++ b/dxlclient/exceptions.py
@@ -34,3 +34,9 @@ class InvalidProxyConfigurationError(Exception):
     """
      Exception raised when specified HTTP proxy address or port is invalid
     """
+
+
+class NoBrokerSpecifiedError(Exception):
+    """
+     Exception raised when no brokers are specified
+    """

--- a/dxlclient/test/test_cli.py
+++ b/dxlclient/test/test_cli.py
@@ -716,7 +716,7 @@ def make_basic_config(client_prefix="client",
                       add_comments=False):
     if add_comments:
         config = ["[General]",
-                  "#useWebSockets = False\n",
+                  "#UseWebSockets = False\n",
                   "[Certs]",
                   "# Truststore client uses to validate broker",
                   "BrokerCertChain = {}".format(ca_bundle_file),
@@ -747,7 +747,7 @@ def make_config(basic_config_lines=None, broker_lines=None, add_general=True):
                      [broker_lines] +
                      [get_web_socket_section(broker_lines)] +
                      (["[General]",
-                       "#useWebSockets = False\n"] if add_general else [])).encode("utf8")
+                       "#UseWebSockets = False\n"] if add_general else [])).encode("utf8")
 
 
 def get_web_socket_section(broker_lines=None):


### PR DESCRIPTION
Making useWebSockets Config key setting consistent with other config key
settings and raising en exception when no brokers specified in the DXL client config file.