### PR TITLE
Use is_alive in favour of isAlive for Python 3.9 compatibility.

### DIFF
--- a/dxlclient/client.py
+++ b/dxlclient/client.py
@@ -499,7 +499,7 @@ class DxlClient(_BaseObject):
 
         # Wait for the connect thread to finish
         if self._thread is not None:
-            while self._thread.isAlive():
+            while self._thread.is_alive():
                 self._thread.join(1)
             self._thread = None
 
@@ -606,7 +606,7 @@ class DxlClient(_BaseObject):
             self._thread_terminate = True
             with self._connect_wait_lock:
                 self._connect_wait_condition.notifyAll()
-            while self._thread.isAlive():
+            while self._thread.is_alive():
                 self._thread.join(1)
             self._thread = None
             logger.debug("Thread terminated.")

--- a/dxlclient/client_config.py
+++ b/dxlclient/client_config.py
@@ -805,7 +805,7 @@ class DxlClientConfig(_BaseObject):
             broker_list = {}
             self._set_value_to_config(self._BROKERS_SECTION, broker_list)
 
-        if len(broker_list) is 0:
+        if len(broker_list) == 0:
             logger.warning("Broker list is empty")
 
         self._brokers = _get_brokers(self._get_value_from_config(

--- a/dxlclient/client_config.py
+++ b/dxlclient/client_config.py
@@ -805,7 +805,7 @@ class DxlClientConfig(_BaseObject):
             broker_list = {}
             self._set_value_to_config(self._BROKERS_SECTION, broker_list)
 
-        if len(broker_list) == 0:
+        if not broker_list:
             logger.warning("Broker list is empty")
 
         self._brokers = _get_brokers(self._get_value_from_config(

--- a/dxlclient/test/sync_request_troughput_test.py
+++ b/dxlclient/test/sync_request_troughput_test.py
@@ -192,7 +192,7 @@ class SyncRequestTroughputRunner(BaseClientTest):
                                         (count == (self.THREAD_COUNT * self.REQUEST_COUNT)):
                                     self.requests_end_time = time.time()
 
-                            if count % 100 is 0:
+                            if count % 100 == 0:
                                 print(str(count) + ", " + str(time.time() - self.requests_start_time))
 
                             # Calulate and track response times


### PR DESCRIPTION
Fixes #52 . This also fixes below syntax warnings : 

```
find . -iname '*.py' | xargs -P4 -I{} python3 -Wall -m py_compile {}  
./dxlclient/client_config.py:808: SyntaxWarning: "is" with a literal. Did you mean "=="?
  if len(broker_list) is 0:
./dxlclient/test/sync_request_troughput_test.py:195: SyntaxWarning: "is" with a literal. Did you mean "=="?
  if count % 100 is 0:
```